### PR TITLE
use xtracing header name constant and make it private

### DIFF
--- a/internal/kafka/client.go
+++ b/internal/kafka/client.go
@@ -9,9 +9,9 @@ import (
 	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
 )
 
-// XTracingHeaderName corresponds to the X-Tracing header to is sent in Kafka messages
+// xTracingHeaderName corresponds to the X-Tracing header to is sent in Kafka messages
 // with some tracing information
-const XTracingHeaderName = "x-tracing"
+const xTracingHeaderName = "x-tracing"
 
 type Client interface {
 	Produce(message *kafka.Message) error
@@ -45,7 +45,7 @@ func addTracingHeader(message *kafka.Message) {
 	now := time.Now()
 
 	message.Headers = append(message.Headers, kafka.Header{
-		Key:   "x-tracing",
+		Key:   xTracingHeaderName,
 		Value: []byte(fmt.Sprintf(`%s,%d`, config.AppName, now.Unix())),
 	})
 }


### PR DESCRIPTION
I think the `xTracingHeaderName` constant should not be exposed outside the kafka package.