### PR TITLE
Add config prefix

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -11,9 +11,13 @@ import (
 	signal_subscriber "github.com/gol4ng/signal"
 )
 
+const (
+	configPrefix = "kafka_mongo_watcher"
+)
+
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-	cfg := config.NewBase(ctx)
+	cfg := config.NewBase(ctx, configPrefix)
 
 	container := service.NewContainer(cfg, ctx)
 	go container.GetTechServer().Start(ctx)

--- a/cmd/watcher/main_test.go
+++ b/cmd/watcher/main_test.go
@@ -32,7 +32,7 @@ func setupConfig(ctx context.Context) {
 	if cfg == nil {
 		os.Setenv("KAFKA_MONGO_WATCHER_PRINT_CONFIG", "false")
 
-		cfg = config.NewBase(ctx)
+		cfg = config.NewBase(ctx, configPrefix)
 		cfg.LogCliVerbose = false
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,10 +43,10 @@ var cfg = &Base{
 
 // NewBase returns a new base configuration
 func TestNewBase(t *testing.T) {
-	os.Setenv("KAFKA_MONGO_WATCHER_PRINT_CONFIG", "false")
+	os.Setenv("PRINT_CONFIG", "false")
 
 	ctx := context.Background()
-	base := NewBase(ctx)
+	base := NewBase(ctx, "")
 
 	assert.IsType(t, new(Base), base)
 	assert.Equal(t, cfg, base)

--- a/vendor/github.com/etf1/go-config/prefix/prefix.go
+++ b/vendor/github.com/etf1/go-config/prefix/prefix.go
@@ -1,0 +1,49 @@
+package prefix
+
+import (
+	"context"
+
+	"github.com/heetch/confita/backend"
+)
+
+// Option is used to configure the prefix backend.
+type Option func(*Backend)
+
+// Backend loads keys using prefix.
+type Backend struct {
+	delimiter string
+	prefix    string
+	backend   backend.Backend
+}
+
+// NewBackend creates a new prefix backend.
+func NewBackend(prefix string, backend backend.Backend, opts ...Option) *Backend {
+	b := &Backend{
+		delimiter: "_",
+		prefix:    prefix,
+		backend:   backend,
+	}
+
+	for _, opt := range opts {
+		opt(b)
+	}
+
+	return b
+}
+
+// WithDelimiter allows to specify a delimiter between prefix and key.
+func WithDelimiter(delimiter string) Option {
+	return func(b *Backend) {
+		b.delimiter = delimiter
+	}
+}
+
+// Get loads the given key using specified key prefix and backend.
+func (b *Backend) Get(ctx context.Context, key string) ([]byte, error) {
+	return b.backend.Get(ctx, b.prefix+b.delimiter+key)
+}
+
+// Name returns the name of the backend.
+func (b *Backend) Name() string {
+	return "prefix_" + b.backend.Name()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,6 +9,7 @@ github.com/davecgh/go-spew/spew
 github.com/etf1/go-config
 github.com/etf1/go-config/dotenv
 github.com/etf1/go-config/env
+github.com/etf1/go-config/prefix
 # github.com/go-stack/stack v1.8.0
 github.com/go-stack/stack
 # github.com/gol4ng/logger v0.5.5


### PR DESCRIPTION
Sometimes you don't want to have a prefix for the configuration variables.
This change will allow to specify a prefix or not for configuration variables.

For example, KAFKA_MONGO_WATCHER_MONGODB_URI will be first tried and then MONGODB_URI.
The prefix is KAFKA_MONGO_WATCHER