### PR TITLE
fix: fermeture des curseurs MongoDB avant l'annulation du contexte (SIGTERM)

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"syscall"
+	"time"
 
 	"github.com/etf1/kafka-mongo-watcher/config"
 	"github.com/etf1/kafka-mongo-watcher/internal/service"
@@ -43,9 +44,13 @@ func handleExitSignal(ctx context.Context, cancel context.CancelFunc, container 
 		log := container.GetLogger()
 		log.Info("Signal received: gracefully stopping application", logger.String("signal", signal.String()))
 
+		// Disconnect MongoDB before cancelling context so killCursors/endSessions commands reach the server.
+		disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer disconnectCancel()
+		container.GetMongoConnection().Client().Disconnect(disconnectCtx)
+
 		cancel()
 		container.GetKafkaClient().Close()
-		container.GetMongoConnection().Client().Disconnect(ctx)
-		container.GetHttpServer().Close(ctx)
+		container.GetHttpServer().Close(disconnectCtx)
 	}, os.Interrupt, syscall.SIGTERM)
 }

--- a/internal/mongo/replay_producer.go
+++ b/internal/mongo/replay_producer.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"time"
 
 	"github.com/etf1/kafka-mongo-watcher/internal/mongo/variables"
 	"github.com/gol4ng/logger"
@@ -57,7 +58,11 @@ func (r *ReplayProducer) Produce(ctx context.Context) (chan *ChangeEvent, error)
 	var events = make(chan *ChangeEvent)
 
 	go func() {
-		defer cursor.Close(ctx)
+		defer func() {
+			closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer closeCancel()
+			_ = cursor.Close(closeCtx)
+		}()
 		defer close(events)
 
 		r.sendEvents(ctx, cursor, events)

--- a/internal/mongo/replay_producer_test.go
+++ b/internal/mongo/replay_producer_test.go
@@ -45,7 +45,7 @@ func TestReplayProduceWhenNoResults(t *testing.T) {
 
 	mongoCursor := NewMockAggregateCursor(ctrl)
 	mongoCursor.EXPECT().Next(ctx).Return(false)
-	mongoCursor.EXPECT().Close(ctx)
+	mongoCursor.EXPECT().Close(gomock.Any())
 
 	mongoCollection := NewMockCollectionAdapter(ctrl)
 	mongoCollection.EXPECT().Database().Return(mongoDatabase)
@@ -108,7 +108,7 @@ func TestReplayProduceWhenHaveResults(t *testing.T) {
 	mongoCursor := NewMockAggregateCursor(ctrl)
 	firstCall := mongoCursor.EXPECT().Next(ctx).Return(true)
 	mongoCursor.EXPECT().Next(ctx).Return(false).After(firstCall)
-	mongoCursor.EXPECT().Close(ctx)
+	mongoCursor.EXPECT().Close(gomock.Any())
 
 	var e ChangeEvent
 	mongoCursor.EXPECT().Decode(&e).Return(nil)
@@ -149,7 +149,7 @@ func TestReplayProduceWhenResultsWithDecodeError(t *testing.T) {
 
 	var e ChangeEvent
 	mongoCursor.EXPECT().Decode(&e).Return(errors.New("decode error"))
-	mongoCursor.EXPECT().Close(ctx)
+	mongoCursor.EXPECT().Close(gomock.Any())
 
 	mongoCollection := NewMockCollectionAdapter(ctrl)
 	mongoCollection.EXPECT().Database().Return(mongoDatabase)
@@ -183,7 +183,7 @@ func TestReplayProduceWhenCustomPipeline(t *testing.T) {
 
 	mongoCursor := NewMockAggregateCursor(ctrl)
 	mongoCursor.EXPECT().Next(ctx).Return(false)
-	mongoCursor.EXPECT().Close(ctx)
+	mongoCursor.EXPECT().Close(gomock.Any())
 
 	mongoCollection := NewMockCollectionAdapter(ctrl)
 	mongoCollection.EXPECT().Database().Return(mongoDatabase)

--- a/internal/mongo/watch_producer.go
+++ b/internal/mongo/watch_producer.go
@@ -42,15 +42,24 @@ func (w *WatchProducer) GetProducer(o ...WatchOption) ChangeEventProducer {
 
 		go func() {
 			defer close(events)
+			defer func() {
+				if cursor != nil {
+					closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+					defer closeCancel()
+					_ = cursor.Close(closeCtx)
+				}
+			}()
 			for {
 				select {
 				case <-ctx.Done():
 					w.logger.Info("Context canceled")
-					cursor.Close(ctx)
 					return
 				case startAfter := <-w.sendEvents(ctx, cursor, events, config.ignoreUpdateDescription):
 					w.logger.Info("Mongo client : Retry to watch collection", logger.String("collection", w.collection.Name()), logger.Any("start_after", startAfter))
-					cursor.Close(ctx)
+					closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+					_ = cursor.Close(closeCtx)
+					closeCancel()
+					cursor = nil
 					if config.maxRetries == 0 {
 						return
 					}
@@ -89,6 +98,12 @@ func (w *WatchProducer) watch(ctx context.Context, pipeline bson.A, config *Watc
 		cursor, err = w.collection.Watch(ctx, pipeline, opts)
 		if err == nil {
 			break
+		}
+		if cursor != nil {
+			closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_ = cursor.Close(closeCtx)
+			closeCancel()
+			cursor = nil
 		}
 		if attempt >= config.maxRetries {
 			w.logger.Warning("failed to open cursor on collection, reach max retries", logger.String("collection", w.collection.Name()), logger.Int32("max_retries", config.maxRetries), logger.Error("error", err))

--- a/internal/mongo/watch_producer_test.go
+++ b/internal/mongo/watch_producer_test.go
@@ -35,7 +35,7 @@ func TestWatchProduceWhenNoResults(t *testing.T) {
 	mongoCollection.EXPECT().Watch(ctx, emptyPipeline, opts).Return(mongoCursor, nil)
 	mongoCollection.EXPECT().Name().Return("coll").AnyTimes()
 	mongoCursor.EXPECT().Next(ctx).Return(false).AnyTimes()
-	mongoCursor.EXPECT().Close(ctx).Return(nil).AnyTimes()
+	mongoCursor.EXPECT().Close(gomock.Any()).Return(nil).AnyTimes()
 	mongoCursor.EXPECT().ResumeToken().Return(bson.Raw{}).AnyTimes()
 
 	watcher := NewWatchProducer(mongoCollection, logger.NewNopLogger(), "")
@@ -73,7 +73,7 @@ func TestWatchProduceWhenWatchError(t *testing.T) {
 	var expectedErr = errors.New("aggregate error")
 	mongoCollection.EXPECT().Watch(ctx, emptyPipeline, opts).Return(mongoCursor, expectedErr)
 	mongoCollection.EXPECT().Name().Return("coll").AnyTimes()
-	mongoCursor.EXPECT().Close(ctx).Return(nil).AnyTimes()
+	mongoCursor.EXPECT().Close(gomock.Any()).Return(nil).AnyTimes()
 
 	watcher := NewWatchProducer(mongoCollection, logger.NewNopLogger(), "")
 
@@ -186,7 +186,7 @@ func TestWatchProduceWhenCustomPipeline(t *testing.T) {
 	mongoCursor.EXPECT().ID().Return(int64(1234)).AnyTimes()
 	mongoCursor.EXPECT().Err().Return(nil).AnyTimes()
 	mongoCursor.EXPECT().ResumeToken().Return(bson.Raw{}).AnyTimes()
-	mongoCursor.EXPECT().Close(ctx).Return(nil).AnyTimes()
+	mongoCursor.EXPECT().Close(gomock.Any()).Return(nil).AnyTimes()
 
 	watcher := NewWatchProducer(mongoCollection, logger.NewNopLogger(), customPipeline)
 


### PR DESCRIPTION
## Cause racine

À la réception d'un `SIGTERM`, `cancel()` était appelé **avant** `Disconnect()` dans `handleExitSignal`. Le contexte annulé empêchait MongoDB de recevoir les commandes `killCursors`/`endSessions`, laissant des curseurs orphelins sur le serveur à chaque redémarrage de pod jusqu'à atteindre la limite.

## Changements

### `cmd/watcher/main.go` — Correction principale
`Disconnect()` s'exécute maintenant **en premier** avec un contexte `background` de 10 secondes, puis `cancel()` est appelé. Cela garantit la fermeture propre du curseur côté serveur à chaque arrêt gracieux.

### `internal/mongo/watch_producer.go` — Filet de sécurité
- Ajout d'un `defer cursor.Close(...)` avec `context.Background()` + timeout de 5s dans la goroutine (couvre les panics et autres chemins de sortie)
- La fermeture explicite sur le chemin de retry utilise aussi `context.Background()` + timeout
- La boucle de retry ferme tout curseur non-nil retourné avec une erreur (défensif, certaines versions du driver peuvent retourner les deux)

### `internal/mongo/replay_producer.go` — Même correction
`defer cursor.Close(ctx)` remplacé par `defer func()` utilisant `context.Background()` + timeout de 5s pour la même raison.

### Tests (`watch_producer_test.go`, `replay_producer_test.go`)
Les attentes mock `Close(ctx)` mises à jour en `Close(gomock.Any())` car on ne passe plus le contexte de test à `Close`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)