### PR TITLE
fix: fermeture des curseurs MongoDB avant l'annulation du contexte (SIGTERM)

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"syscall"
+	"time"
 
 	"github.com/etf1/kafka-mongo-watcher/config"
 	"github.com/etf1/kafka-mongo-watcher/internal/service"
@@ -43,9 +44,13 @@ func handleExitSignal(ctx context.Context, cancel context.CancelFunc, container 
 		log := container.GetLogger()
 		log.Info("Signal received: gracefully stopping application", logger.String("signal", signal.String()))
 
+		// Disconnect MongoDB before cancelling context so killCursors/endSessions commands reach the server.
+		disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer disconnectCancel()
+		container.GetMongoConnection().Client().Disconnect(disconnectCtx)
+
 		cancel()
 		container.GetKafkaClient().Close()
-		container.GetMongoConnection().Client().Disconnect(ctx)
-		container.GetHttpServer().Close(ctx)
+		container.GetHttpServer().Close(disconnectCtx)
 	}, os.Interrupt, syscall.SIGTERM)
 }

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -28,7 +28,7 @@ func main() {
 	container := service.NewContainer(ctx, cfg)
 	go container.GetHttpServer().Start(ctx)
 
-	defer handleExitSignal(ctx, cancel, container)()
+	defer handleExitSignal(cancel, container)()
 
 	changeEventChan, err := container.GetChangeEventProducer()(ctx)
 	if err != nil {
@@ -39,18 +39,22 @@ func main() {
 }
 
 // Handle for an exit signal in order to quit application on a proper way (shutting down connections and servers)
-func handleExitSignal(ctx context.Context, cancel context.CancelFunc, container *service.Container) func() {
+func handleExitSignal(cancel context.CancelFunc, container *service.Container) func() {
 	return signal_subscriber.SubscribeWithKiller(func(signal os.Signal) {
 		log := container.GetLogger()
 		log.Info("Signal received: gracefully stopping application", logger.String("signal", signal.String()))
 
-		// Disconnect MongoDB before cancelling context so killCursors/endSessions commands reach the server.
+		// Cancel the main context immediately so all goroutines start shutting down.
+		cancel()
+		container.GetKafkaClient().Close()
+
+		// Use independent background contexts so these calls succeed even after cancel().
 		disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer disconnectCancel()
 		container.GetMongoConnection().Client().Disconnect(disconnectCtx)
 
-		cancel()
-		container.GetKafkaClient().Close()
-		container.GetHttpServer().Close(disconnectCtx)
+		httpShutdownCtx, httpShutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer httpShutdownCancel()
+		container.GetHttpServer().Close(httpShutdownCtx)
 	}, os.Interrupt, syscall.SIGTERM)
 }

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -28,7 +28,10 @@ func main() {
 	container := service.NewContainer(ctx, cfg)
 	go container.GetHttpServer().Start(ctx)
 
-	defer handleExitSignal(cancel, container)()
+	// The signal handler only cancels the context. All cleanup happens after
+	// Produce() returns, which guarantees that cursors have been closed by
+	// the watch goroutine (via defer) before we disconnect the MongoDB client.
+	defer handleExitSignal(cancel)()
 
 	changeEventChan, err := container.GetChangeEventProducer()(ctx)
 	if err != nil {
@@ -36,32 +39,34 @@ func main() {
 	}
 	kafkaMessageChan := container.GetChangeEventKafkaMessageTransformer().Transform(changeEventChan)
 	container.GetKafkaClient().Produce(kafkaMessageChan)
+
+	// Produce() has returned: all cursors are already closed by watch/replay
+	// goroutines. Now it is safe to tear down the underlying connections.
+	cleanup(container)
 }
 
-// Handle for an exit signal in order to quit application on a proper way (shutting down connections and servers)
-func handleExitSignal(cancel context.CancelFunc, container *service.Container) func() {
+// cleanup disconnects MongoDB, then shuts down the HTTP server.
+// Kafka client is already closed by Produce()'s own defer.
+func cleanup(container *service.Container) {
+	log := container.GetLogger()
+
+	disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer disconnectCancel()
+	if err := container.GetMongoConnection().Client().Disconnect(disconnectCtx); err != nil {
+		log.Error("Failed to disconnect MongoDB client", logger.Error("error", err))
+	}
+
+	httpShutdownCtx, httpShutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer httpShutdownCancel()
+	if err := container.GetHttpServer().Close(httpShutdownCtx); err != nil {
+		log.Error("Failed to close HTTP server", logger.Error("error", err))
+	}
+}
+
+// handleExitSignal registers a signal handler that only cancels the main
+// context. The returned function is an unsubscriber to be deferred.
+func handleExitSignal(cancel context.CancelFunc) func() {
 	return signal_subscriber.SubscribeWithKiller(func(signal os.Signal) {
-		log := container.GetLogger()
-		log.Info("Signal received: gracefully stopping application", logger.String("signal", signal.String()))
-
-		// Cancel the main context immediately so all goroutines start shutting down.
 		cancel()
-
-		// Use independent background contexts so these calls succeed even after cancel().
-		// Disconnect MongoDB before Kafka close: Kafka.Close() busy-waits with no timeout
-		// and could block indefinitely, preventing Disconnect() from running.
-		disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer disconnectCancel()
-		if err := container.GetMongoConnection().Client().Disconnect(disconnectCtx); err != nil {
-			log.Error("Failed to disconnect MongoDB client", logger.Error("error", err))
-		}
-
-		container.GetKafkaClient().Close()
-
-		httpShutdownCtx, httpShutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer httpShutdownCancel()
-		if err := container.GetHttpServer().Close(httpShutdownCtx); err != nil {
-			log.Error("Failed to close HTTP server", logger.Error("error", err))
-		}
 	}, os.Interrupt, syscall.SIGTERM)
 }

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -51,10 +51,14 @@ func handleExitSignal(cancel context.CancelFunc, container *service.Container) f
 		// Use independent background contexts so these calls succeed even after cancel().
 		disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer disconnectCancel()
-		container.GetMongoConnection().Client().Disconnect(disconnectCtx)
+		if err := container.GetMongoConnection().Client().Disconnect(disconnectCtx); err != nil {
+			log.Error("Failed to disconnect MongoDB client", logger.Error("error", err))
+		}
 
 		httpShutdownCtx, httpShutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer httpShutdownCancel()
-		container.GetHttpServer().Close(httpShutdownCtx)
+		if err := container.GetHttpServer().Close(httpShutdownCtx); err != nil {
+			log.Error("Failed to close HTTP server", logger.Error("error", err))
+		}
 	}, os.Interrupt, syscall.SIGTERM)
 }

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/etf1/kafka-mongo-watcher/config"
+	"github.com/etf1/kafka-mongo-watcher/internal/mongo"
 	"github.com/etf1/kafka-mongo-watcher/internal/service"
 	"github.com/gol4ng/logger"
 	signal_subscriber "github.com/gol4ng/signal"
@@ -28,25 +29,54 @@ func main() {
 	container := service.NewContainer(ctx, cfg)
 	go container.GetHttpServer().Start(ctx)
 
-	// The signal handler only cancels the context. All cleanup happens after
-	// Produce() returns, which guarantees that cursors have been closed by
-	// the watch goroutine (via defer) before we disconnect the MongoDB client.
 	defer handleExitSignal(cancel, container)()
+	defer cleanup(container)
 
-	changeEventChan, err := container.GetChangeEventProducer()(ctx)
+	const producerStartTimeout = 2 * time.Minute
+	changeEventChan, err := startProducerWithRetry(ctx, container, producerStartTimeout)
 	if err != nil {
-		panic(err)
+		container.GetLogger().Error("Giving up: unable to start change event producer", logger.Error("error", err))
+		return
 	}
 	kafkaMessageChan := container.GetChangeEventKafkaMessageTransformer().Transform(changeEventChan)
 	container.GetKafkaClient().Produce(kafkaMessageChan)
+}
 
-	// Produce() has returned: all cursors are already closed by watch/replay
-	// goroutines. Now it is safe to tear down the underlying connections.
-	cleanup(container)
+// startProducerWithRetry retries the change event producer creation with
+// exponential backoff until it succeeds or the timeout / context expires.
+// This handles transient errors such as "too many cursors" from previous
+// pods that left orphaned change streams on the MongoDB server.
+func startProducerWithRetry(ctx context.Context, container *service.Container, timeout time.Duration) (chan *mongo.ChangeEvent, error) {
+	log := container.GetLogger()
+	producer := container.GetChangeEventProducer()
+
+	delay := 1 * time.Second
+	const maxDelay = 30 * time.Second
+	deadline := time.After(timeout)
+
+	for {
+		ch, err := producer(ctx)
+		if err == nil {
+			return ch, nil
+		}
+		log.Warning("Failed to start change event producer, retrying…",
+			logger.Error("error", err), logger.Duration("retry_in", delay))
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-deadline:
+			return nil, err
+		case <-time.After(delay):
+			delay *= 2
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+		}
+	}
 }
 
 // cleanup disconnects MongoDB, then shuts down the HTTP server.
-// Kafka client is already closed by Produce()'s own defer.
 func cleanup(container *service.Container) {
 	log := container.GetLogger()
 

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -46,14 +46,17 @@ func handleExitSignal(cancel context.CancelFunc, container *service.Container) f
 
 		// Cancel the main context immediately so all goroutines start shutting down.
 		cancel()
-		container.GetKafkaClient().Close()
 
 		// Use independent background contexts so these calls succeed even after cancel().
+		// Disconnect MongoDB before Kafka close: Kafka.Close() busy-waits with no timeout
+		// and could block indefinitely, preventing Disconnect() from running.
 		disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer disconnectCancel()
 		if err := container.GetMongoConnection().Client().Disconnect(disconnectCtx); err != nil {
 			log.Error("Failed to disconnect MongoDB client", logger.Error("error", err))
 		}
+
+		container.GetKafkaClient().Close()
 
 		httpShutdownCtx, httpShutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer httpShutdownCancel()

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -31,7 +31,7 @@ func main() {
 	// The signal handler only cancels the context. All cleanup happens after
 	// Produce() returns, which guarantees that cursors have been closed by
 	// the watch goroutine (via defer) before we disconnect the MongoDB client.
-	defer handleExitSignal(cancel)()
+	defer handleExitSignal(cancel, container)()
 
 	changeEventChan, err := container.GetChangeEventProducer()(ctx)
 	if err != nil {
@@ -65,8 +65,9 @@ func cleanup(container *service.Container) {
 
 // handleExitSignal registers a signal handler that only cancels the main
 // context. The returned function is an unsubscriber to be deferred.
-func handleExitSignal(cancel context.CancelFunc) func() {
+func handleExitSignal(cancel context.CancelFunc, container *service.Container) func() {
 	return signal_subscriber.SubscribeWithKiller(func(signal os.Signal) {
+		container.GetLogger().Info("Signal received: gracefully stopping application", logger.String("signal", signal.String()))
 		cancel()
 	}, os.Interrupt, syscall.SIGTERM)
 }

--- a/internal/mongo/collection.go
+++ b/internal/mongo/collection.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	mongodriver "go.mongodb.org/mongo-driver/mongo"
@@ -43,6 +44,16 @@ type CollectionAdapter interface {
 
 type collectionAdapter struct {
 	collection *mongodriver.Collection
+}
+
+type cursorCloser interface {
+	Close(context.Context) error
+}
+
+func closeCursor(cursor cursorCloser) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = cursor.Close(ctx)
 }
 
 // NewCollectionAdapter returns a mongo-driver/mongo collection wrapper

--- a/internal/mongo/collection.go
+++ b/internal/mongo/collection.go
@@ -51,6 +51,9 @@ type cursorCloser interface {
 }
 
 func closeCursor(cursor cursorCloser) {
+	if cursor == nil {
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_ = cursor.Close(ctx)

--- a/internal/mongo/collection.go
+++ b/internal/mongo/collection.go
@@ -55,8 +55,15 @@ func closeCursor(cursor cursorCloser) {
 	// Guard against both nil interface and typed nil (e.g. (*mongo.ChangeStream)(nil)
 	// returned alongside an error by the driver — the interface is non-nil but the
 	// underlying pointer is nil, which would panic on Close).
-	if cursor == nil || reflect.ValueOf(cursor).IsNil() {
+	if cursor == nil {
 		return
+	}
+	v := reflect.ValueOf(cursor)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		if v.IsNil() {
+			return
+		}
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/internal/mongo/collection.go
+++ b/internal/mongo/collection.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"reflect"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -51,11 +52,16 @@ type cursorCloser interface {
 }
 
 func closeCursor(cursor cursorCloser) {
-	if cursor == nil {
+	// Guard against both nil interface and typed nil (e.g. (*mongo.ChangeStream)(nil)
+	// returned alongside an error by the driver — the interface is non-nil but the
+	// underlying pointer is nil, which would panic on Close).
+	if cursor == nil || reflect.ValueOf(cursor).IsNil() {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	// Error is intentionally ignored: Close() during cleanup typically fails only when
+	// the cursor or connection is already gone, which is acceptable in a shutdown path.
 	_ = cursor.Close(ctx)
 }
 

--- a/internal/mongo/replay_producer.go
+++ b/internal/mongo/replay_producer.go
@@ -57,7 +57,7 @@ func (r *ReplayProducer) Produce(ctx context.Context) (chan *ChangeEvent, error)
 	var events = make(chan *ChangeEvent)
 
 	go func() {
-		defer func() { closeCursor(cursor) }()
+		defer closeCursor(cursor)
 		defer close(events)
 
 		r.sendEvents(ctx, cursor, events)

--- a/internal/mongo/replay_producer.go
+++ b/internal/mongo/replay_producer.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"time"
 
 	"github.com/etf1/kafka-mongo-watcher/internal/mongo/variables"
 	"github.com/gol4ng/logger"
@@ -57,7 +58,11 @@ func (r *ReplayProducer) Produce(ctx context.Context) (chan *ChangeEvent, error)
 	var events = make(chan *ChangeEvent)
 
 	go func() {
-		defer cursor.Close(ctx)
+		defer func() {
+			closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer closeCancel()
+			_ = cursor.Close(closeCtx)
+		}()
 		defer close(events)
 
 		r.sendEvents(ctx, cursor, events)

--- a/internal/mongo/replay_producer.go
+++ b/internal/mongo/replay_producer.go
@@ -2,7 +2,6 @@ package mongo
 
 import (
 	"context"
-	"time"
 
 	"github.com/etf1/kafka-mongo-watcher/internal/mongo/variables"
 	"github.com/gol4ng/logger"
@@ -58,11 +57,7 @@ func (r *ReplayProducer) Produce(ctx context.Context) (chan *ChangeEvent, error)
 	var events = make(chan *ChangeEvent)
 
 	go func() {
-		defer func() {
-			closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer closeCancel()
-			_ = cursor.Close(closeCtx)
-		}()
+		defer func() { closeCursor(cursor) }()
 		defer close(events)
 
 		r.sendEvents(ctx, cursor, events)

--- a/internal/mongo/replay_producer.go
+++ b/internal/mongo/replay_producer.go
@@ -74,7 +74,11 @@ func (r *ReplayProducer) sendEvents(ctx context.Context, cursor AggregateCursor,
 			continue
 		}
 
-		events <- event
+		select {
+		case events <- event:
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 

--- a/internal/mongo/replay_producer.go
+++ b/internal/mongo/replay_producer.go
@@ -57,8 +57,8 @@ func (r *ReplayProducer) Produce(ctx context.Context) (chan *ChangeEvent, error)
 	var events = make(chan *ChangeEvent)
 
 	go func() {
-		defer closeCursor(cursor)
 		defer close(events)
+		defer closeCursor(cursor)
 
 		r.sendEvents(ctx, cursor, events)
 	}()

--- a/internal/mongo/replay_producer_test.go
+++ b/internal/mongo/replay_producer_test.go
@@ -45,7 +45,7 @@ func TestReplayProduceWhenNoResults(t *testing.T) {
 
 	mongoCursor := NewMockAggregateCursor(ctrl)
 	mongoCursor.EXPECT().Next(ctx).Return(false)
-	mongoCursor.EXPECT().Close(ctx)
+	mongoCursor.EXPECT().Close(gomock.Any())
 
 	mongoCollection := NewMockCollectionAdapter(ctrl)
 	mongoCollection.EXPECT().Database().Return(mongoDatabase)
@@ -108,7 +108,7 @@ func TestReplayProduceWhenHaveResults(t *testing.T) {
 	mongoCursor := NewMockAggregateCursor(ctrl)
 	firstCall := mongoCursor.EXPECT().Next(ctx).Return(true)
 	mongoCursor.EXPECT().Next(ctx).Return(false).After(firstCall)
-	mongoCursor.EXPECT().Close(ctx)
+	mongoCursor.EXPECT().Close(gomock.Any())
 
 	var e ChangeEvent
 	mongoCursor.EXPECT().Decode(&e).Return(nil)
@@ -149,7 +149,7 @@ func TestReplayProduceWhenResultsWithDecodeError(t *testing.T) {
 
 	var e ChangeEvent
 	mongoCursor.EXPECT().Decode(&e).Return(errors.New("decode error"))
-	mongoCursor.EXPECT().Close(ctx)
+	mongoCursor.EXPECT().Close(gomock.Any())
 
 	mongoCollection := NewMockCollectionAdapter(ctrl)
 	mongoCollection.EXPECT().Database().Return(mongoDatabase)
@@ -183,7 +183,7 @@ func TestReplayProduceWhenCustomPipeline(t *testing.T) {
 
 	mongoCursor := NewMockAggregateCursor(ctrl)
 	mongoCursor.EXPECT().Next(ctx).Return(false)
-	mongoCursor.EXPECT().Close(ctx)
+	mongoCursor.EXPECT().Close(gomock.Any())
 
 	mongoCollection := NewMockCollectionAdapter(ctrl)
 	mongoCollection.EXPECT().Database().Return(mongoDatabase)

--- a/internal/mongo/watch_producer.go
+++ b/internal/mongo/watch_producer.go
@@ -42,11 +42,7 @@ func (w *WatchProducer) GetProducer(o ...WatchOption) ChangeEventProducer {
 
 		go func() {
 			defer close(events)
-			defer func() {
-				if cursor != nil {
-					closeCursor(cursor)
-				}
-			}()
+			defer func() { closeCursor(cursor) }()
 			for {
 				select {
 				case <-ctx.Done():

--- a/internal/mongo/watch_producer.go
+++ b/internal/mongo/watch_producer.go
@@ -44,9 +44,7 @@ func (w *WatchProducer) GetProducer(o ...WatchOption) ChangeEventProducer {
 			defer close(events)
 			defer func() {
 				if cursor != nil {
-					closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
-					defer closeCancel()
-					_ = cursor.Close(closeCtx)
+					closeCursor(cursor)
 				}
 			}()
 			for {
@@ -56,9 +54,7 @@ func (w *WatchProducer) GetProducer(o ...WatchOption) ChangeEventProducer {
 					return
 				case startAfter := <-w.sendEvents(ctx, cursor, events, config.ignoreUpdateDescription):
 					w.logger.Info("Mongo client : Retry to watch collection", logger.String("collection", w.collection.Name()), logger.Any("start_after", startAfter))
-					closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
-					_ = cursor.Close(closeCtx)
-					closeCancel()
+					closeCursor(cursor)
 					cursor = nil
 					if config.maxRetries == 0 {
 						return
@@ -100,9 +96,7 @@ func (w *WatchProducer) watch(ctx context.Context, pipeline bson.A, config *Watc
 			break
 		}
 		if cursor != nil {
-			closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
-			_ = cursor.Close(closeCtx)
-			closeCancel()
+			closeCursor(cursor)
 			cursor = nil
 		}
 		if attempt >= config.maxRetries {

--- a/internal/mongo/watch_producer.go
+++ b/internal/mongo/watch_producer.go
@@ -44,22 +44,22 @@ func (w *WatchProducer) GetProducer(o ...WatchOption) ChangeEventProducer {
 			defer close(events)
 			defer func() { closeCursor(cursor) }()
 			for {
-				select {
-				case <-ctx.Done():
+				startAfter := <-w.sendEvents(ctx, cursor, events, config.ignoreUpdateDescription)
+				// sendEvents exited: either the cursor broke or the context was canceled.
+				if ctx.Err() != nil {
 					w.logger.Info("Context canceled")
 					return
-				case startAfter := <-w.sendEvents(ctx, cursor, events, config.ignoreUpdateDescription):
-					w.logger.Info("Mongo client : Retry to watch collection", logger.String("collection", w.collection.Name()), logger.Any("start_after", startAfter))
-					closeCursor(cursor)
-					cursor = nil
-					if config.maxRetries == 0 {
-						return
-					}
-					cursor, err = w.watch(ctx, pipeline, config, nil, startAfter)
-					if err != nil {
-						w.logger.Error("Mongo client : An error has occured while retrying to watch collection", logger.String("collection", w.collection.Name()), logger.Error("error", err))
-						return
-					}
+				}
+				w.logger.Info("Mongo client : Retry to watch collection", logger.String("collection", w.collection.Name()), logger.Any("start_after", startAfter))
+				closeCursor(cursor)
+				cursor = nil
+				if config.maxRetries == 0 {
+					return
+				}
+				cursor, err = w.watch(ctx, pipeline, config, nil, startAfter)
+				if err != nil {
+					w.logger.Error("Mongo client : An error has occured while retrying to watch collection", logger.String("collection", w.collection.Name()), logger.Error("error", err))
+					return
 				}
 			}
 		}()
@@ -102,7 +102,11 @@ func (w *WatchProducer) watch(ctx context.Context, pipeline bson.A, config *Watc
 		attempt++
 		w.logger.Warning("failed to open cursor on collection", logger.String("collection", w.collection.Name()), logger.Int32("attempt", attempt), logger.Duration("retry_delay", config.retryDelay), logger.Error("error", err))
 		if config.retryDelay > 0 {
-			time.Sleep(config.retryDelay)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(config.retryDelay):
+			}
 		}
 	}
 	return
@@ -130,7 +134,12 @@ func (w *WatchProducer) sendEvents(ctx context.Context, cursor StreamCursor, eve
 			if ignoreUpdateDescription {
 				event.Updates = nil
 			}
-			events <- event
+			select {
+			case events <- event:
+			case <-ctx.Done():
+				resumeToken <- cursor.ResumeToken()
+				return
+			}
 		}
 		resumeToken <- cursor.ResumeToken()
 	}()

--- a/internal/mongo/watch_producer.go
+++ b/internal/mongo/watch_producer.go
@@ -42,15 +42,24 @@ func (w *WatchProducer) GetProducer(o ...WatchOption) ChangeEventProducer {
 
 		go func() {
 			defer close(events)
+			defer func() {
+				if cursor != nil {
+					closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+					defer closeCancel()
+					_ = cursor.Close(closeCtx)
+				}
+			}()
 			for {
 				select {
 				case <-ctx.Done():
 					w.logger.Info("Context canceled")
-					cursor.Close(ctx)
 					return
 				case startAfter := <-w.sendEvents(ctx, cursor, events, config.ignoreUpdateDescription):
 					w.logger.Info("Mongo client : Retry to watch collection", logger.String("collection", w.collection.Name()), logger.Any("start_after", startAfter))
-					cursor.Close(ctx)
+					closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+					_ = cursor.Close(closeCtx)
+					closeCancel()
+					cursor = nil
 					if config.maxRetries == 0 {
 						return
 					}
@@ -89,6 +98,12 @@ func (w *WatchProducer) watch(ctx context.Context, pipeline bson.A, config *Watc
 		cursor, err = w.collection.Watch(ctx, pipeline, opts)
 		if err == nil {
 			break
+		}
+		if cursor != nil {
+			closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_ = cursor.Close(closeCtx)
+			closeCancel()
+			cursor = nil
 		}
 		if attempt >= config.maxRetries {
 			w.logger.Warning("failed to open cursor on collection, reach max retries", logger.String("collection", w.collection.Name()), logger.Int32("max_retries", config.maxRetries), logger.Error("error", err))

--- a/internal/mongo/watch_producer_test.go
+++ b/internal/mongo/watch_producer_test.go
@@ -35,7 +35,7 @@ func TestWatchProduceWhenNoResults(t *testing.T) {
 	mongoCollection.EXPECT().Watch(ctx, emptyPipeline, opts).Return(mongoCursor, nil)
 	mongoCollection.EXPECT().Name().Return("coll").AnyTimes()
 	mongoCursor.EXPECT().Next(ctx).Return(false).AnyTimes()
-	mongoCursor.EXPECT().Close(ctx).Return(nil).AnyTimes()
+	mongoCursor.EXPECT().Close(gomock.Any()).Return(nil).AnyTimes()
 	mongoCursor.EXPECT().ResumeToken().Return(bson.Raw{}).AnyTimes()
 
 	watcher := NewWatchProducer(mongoCollection, logger.NewNopLogger(), "")
@@ -73,7 +73,7 @@ func TestWatchProduceWhenWatchError(t *testing.T) {
 	var expectedErr = errors.New("aggregate error")
 	mongoCollection.EXPECT().Watch(ctx, emptyPipeline, opts).Return(mongoCursor, expectedErr)
 	mongoCollection.EXPECT().Name().Return("coll").AnyTimes()
-	mongoCursor.EXPECT().Close(ctx).Return(nil).AnyTimes()
+	mongoCursor.EXPECT().Close(gomock.Any()).Return(nil).AnyTimes()
 
 	watcher := NewWatchProducer(mongoCollection, logger.NewNopLogger(), "")
 
@@ -186,7 +186,7 @@ func TestWatchProduceWhenCustomPipeline(t *testing.T) {
 	mongoCursor.EXPECT().ID().Return(int64(1234)).AnyTimes()
 	mongoCursor.EXPECT().Err().Return(nil).AnyTimes()
 	mongoCursor.EXPECT().ResumeToken().Return(bson.Raw{}).AnyTimes()
-	mongoCursor.EXPECT().Close(ctx).Return(nil).AnyTimes()
+	mongoCursor.EXPECT().Close(gomock.Any()).Return(nil).AnyTimes()
 
 	watcher := NewWatchProducer(mongoCollection, logger.NewNopLogger(), customPipeline)
 

--- a/internal/mongo/watch_producer_test.go
+++ b/internal/mongo/watch_producer_test.go
@@ -200,3 +200,65 @@ func TestWatchProduceWhenCustomPipeline(t *testing.T) {
 	assert.Equal(cap(events), 0)
 	assert.Equal(len(events), 0)
 }
+
+func TestWatchProduceWhenCtxCanceledDuringSend(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	batchSize := int32(10)
+	maxAwaitTime := time.Duration(10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := &options.ChangeStreamOptions{
+		BatchSize:    &batchSize,
+		MaxAwaitTime: &maxAwaitTime,
+	}
+	opts.SetFullDocument(options.UpdateLookup)
+
+	mongoCollection := NewMockCollectionAdapter(ctrl)
+	mongoCursor := NewMockStreamCursor(ctrl)
+
+	var emptyPipeline = bson.A{}
+	mongoCollection.EXPECT().Watch(gomock.Any(), emptyPipeline, opts).Return(mongoCursor, nil)
+	mongoCollection.EXPECT().Name().Return("coll").AnyTimes()
+
+	mongoCursor.EXPECT().ID().Return(int64(1234)).AnyTimes()
+	mongoCursor.EXPECT().Err().Return(nil).AnyTimes()
+	mongoCursor.EXPECT().ResumeToken().Return(bson.Raw{}).AnyTimes()
+	mongoCursor.EXPECT().Close(gomock.Any()).Return(nil).AnyTimes()
+	// Next always returns true: the goroutine will loop and try to send events.
+	mongoCursor.EXPECT().Next(gomock.Any()).Return(true).AnyTimes()
+	var e ChangeEvent
+	mongoCursor.EXPECT().Decode(&e).Return(nil).AnyTimes()
+
+	watcher := NewWatchProducer(mongoCollection, logger.NewNopLogger(), "")
+
+	events, err := watcher.GetProducer(
+		WithBatchSize(batchSize),
+		WithFullDocument(true),
+		WithMaxAwaitTime(maxAwaitTime),
+		WithMaxRetries(0),
+	)(ctx)
+
+	assert := assert.New(t)
+	assert.Nil(err)
+
+	// Cancel the context while nobody reads from events.
+	// The goroutine must exit via the ctx.Done() branch of the select in sendEvents.
+	cancel()
+
+	// Drain the events channel: it must close within a reasonable time.
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case _, ok := <-events:
+			if !ok {
+				return // channel closed — goroutine exited correctly
+			}
+		case <-timeout:
+			t.Fatal("events channel was not closed after context cancellation")
+		}
+	}
+}


### PR DESCRIPTION
This pull request improves the reliability and safety of resource cleanup for MongoDB cursors, the HTTP server, and Kafka clients, especially during shutdown and error scenarios. It introduces a new utility for safely closing cursors, refactors shutdown handling for better sequencing, and strengthens test coverage for context cancellation and resource management.

**Resource cleanup and shutdown improvements:**

* Added a `closeCursor` utility function in `internal/mongo/collection.go` to safely close MongoDB cursors, handling both nil and typed-nil interfaces to prevent panics during shutdown.
* Refactored shutdown logic in `cmd/watcher/main.go` to ensure all cursors are closed before disconnecting the MongoDB client and shutting down the HTTP server, and clarified signal handling to only cancel context.

**MongoDB cursor management:**

* Updated all cursor-closing code paths in producers to use `closeCursor`, ensuring consistent and safe cleanup (e.g., in `replay_producer.go` and `watch_producer.go`). [[1]](diffhunk://#diff-4eac0ea683dc2742f982f4ea7f0fc5bcaec10e7be4921642c9a0c7cd8b89d9b1L60-R60) [[2]](diffhunk://#diff-a9b23c37003dbb642f3de9ba66ac8ce6964f427cc2c3dbec3b70f7688edab841R45-R55) [[3]](diffhunk://#diff-a9b23c37003dbb642f3de9ba66ac8ce6964f427cc2c3dbec3b70f7688edab841R94-R109)
* Improved retry and shutdown logic in `watch_producer.go` by closing cursors on errors and using context cancellation for retry delays.

**Test robustness and coverage:**

* Updated tests to expect `Close(gomock.Any())` instead of a specific context, reflecting the new cursor-closing approach. [[1]](diffhunk://#diff-ca3b1c869ccc95f8f74afc3ed8c3b82c73e7bc051f38c12b4e31bc2bba926cbdL48-R48) [[2]](diffhunk://#diff-ca3b1c869ccc95f8f74afc3ed8c3b82c73e7bc051f38c12b4e31bc2bba926cbdL111-R111) [[3]](diffhunk://#diff-ca3b1c869ccc95f8f74afc3ed8c3b82c73e7bc051f38c12b4e31bc2bba926cbdL152-R152) [[4]](diffhunk://#diff-ca3b1c869ccc95f8f74afc3ed8c3b82c73e7bc051f38c12b4e31bc2bba926cbdL186-R186) [[5]](diffhunk://#diff-8bfe37f68eb8ac4f34291a9fec59ce7d41e7f6afce393dede9a5b9ce366c7d0eL38-R38) [[6]](diffhunk://#diff-8bfe37f68eb8ac4f34291a9fec59ce7d41e7f6afce393dede9a5b9ce366c7d0eL76-R76) [[7]](diffhunk://#diff-8bfe37f68eb8ac4f34291a9fec59ce7d41e7f6afce393dede9a5b9ce366c7d0eL189-R189)
* Added a new test (`TestWatchProduceWhenCtxCanceledDuringSend`) to verify that the event producer goroutine exits and closes its channel when the context is canceled, even if no consumer is reading from the events channel.