### PR TITLE
feat: Add origin header in the kafka message

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Configuration variables with prefix are first loaded and then without prefix. Fo
 
 **Hint 1**: You can also use some built-in variables such as `%currentTimestamp%` that will put the current timestamp value right in the aggregation pipeline.
 
-**Hint 2**: Each kafka message include an `x-origin` header with two possible values. `watcher` in normal mode and `replay` when replay is enabled.
-
 *Example value with variables*: `[ { "$match": { "date": { "$gt": { "$date": { "$numberLong": "%currentTimestamp%" } } } } } ]`
+
+**Hint 2**: Each kafka message include an `x-origin` header with two possible values. `watcher` in normal mode and `replay` when replay is enabled.
 
 #### MONGODB_URI
 *Type*: string

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ Configuration variables with prefix are first loaded and then without prefix. Fo
 
 *Description*: In case you want to send all collection's documents once (default: false)
 
-**Hint**: You can also use some built-in variables such as `%currentTimestamp%` that will put the current timestamp value right in the aggregation pipeline.
+**Hint 1**: You can also use some built-in variables such as `%currentTimestamp%` that will put the current timestamp value right in the aggregation pipeline.
+
+**Hint 2**: Each kafka message include an `x-origin` header with two possible values. `watcher` in normal mode and `replay` when replay is enabled.
 
 *Example value with variables*: `[ { "$match": { "date": { "$gt": { "$date": { "$numberLong": "%currentTimestamp%" } } } } } ]`
 

--- a/internal/kafka/client_origin.go
+++ b/internal/kafka/client_origin.go
@@ -1,0 +1,58 @@
+package kafka
+
+import (
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+)
+
+// XOriginHeaderName corresponds to the X-Origin header to is sent in Kafka messages
+// with some origin information
+const XOriginHeaderName = "x-origin"
+
+// AddOriginHeader simply adds an origin header with the provided origin information
+// to enable simple debugging
+func AddOriginHeader(message *Message, origin string) {
+	message.Headers = append(message.Headers, Header{
+		Key:   XOriginHeaderName,
+		Value: []byte(origin),
+	})
+}
+
+type originFunc func(message *Message, origin string)
+
+type clientOrigin struct {
+	client Client
+	fn     originFunc
+	origin string
+}
+
+// NewClientOrigin returns a kafka client that allows adding origin information from an original client
+func NewClientOrigin(cli Client, origin string, fn originFunc) *clientOrigin {
+	return &clientOrigin{
+		client: cli,
+		fn:     fn,
+		origin: origin,
+	}
+}
+
+// Produce adds origin information on the message and then produces it
+func (c *clientOrigin) Produce(messages chan *Message) {
+	var next = make(chan *Message, len(messages))
+	go func() {
+		defer close(next)
+		for message := range messages {
+			c.fn(message, c.origin)
+			next <- message
+		}
+	}()
+
+	c.client.Produce(next)
+}
+
+// Events returns the kafka producer events
+func (c *clientOrigin) Events() chan kafka.Event {
+	return c.client.Events()
+}
+
+func (c *clientOrigin) Close() {
+	c.client.Close()
+}

--- a/internal/kafka/client_origin_test.go
+++ b/internal/kafka/client_origin_test.go
@@ -1,0 +1,125 @@
+package kafka
+
+import (
+	"testing"
+	"time"
+
+	kafkaconfluent "github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type OriginMock struct {
+	mock.Mock
+}
+
+func (o OriginMock) Function(msg *Message, origin string) {
+	o.Called(msg, origin)
+}
+
+func TestNewClientOrigin(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Given
+	client := NewMockClient(ctrl)
+
+	addOriginFn := func(message *Message, origin string) {
+		message.Headers = append(message.Headers, Header{
+			Key:   "my-test-key",
+			Value: []byte(origin),
+		})
+	}
+
+	// When
+	cli := NewClientOrigin(client, "my-origin", addOriginFn)
+
+	// Then
+	assert.IsType(t, new(clientOrigin), cli)
+	assert.Equal(t, client, cli.client)
+	assert.Equal(t, "my-origin", cli.origin)
+	assert.IsType(t, originFunc(nil), cli.fn)
+}
+
+func TestClientOriginProduce(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Given
+	messages := make(chan *Message)
+	message := &Message{
+		Topic: "test-topic",
+	}
+
+	go func() {
+		defer close(messages)
+		messages <- message
+	}()
+
+	client := NewMockClient(ctrl)
+	client.EXPECT().Produce(gomock.AssignableToTypeOf(messages))
+
+	var originMock OriginMock
+	originMock.On("Function", message, "my-origin")
+
+	cli := NewClientOrigin(client, "my-origin", originMock.Function)
+
+	// When - Then
+	cli.Produce(messages)
+	time.Sleep(100 * time.Millisecond) // Wait for incoming channel to be read
+}
+
+func TestClientOriginEvents(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Given
+	events := make(chan kafkaconfluent.Event)
+	client := NewMockClient(ctrl)
+	client.EXPECT().Events().Return(events)
+
+	cli := NewClientOrigin(client, "my-origin", func(message *Message, origin string) {})
+
+	// When
+	result := cli.Events()
+
+	// Then
+	assert.Equal(t, events, result)
+}
+
+func TestClientOriginClose(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Given
+	client := NewMockClient(ctrl)
+	client.EXPECT().Close()
+
+	cli := NewClientOrigin(client, "my-origin", func(message *Message, origin string) {
+		message.Headers = append(message.Headers, Header{
+			Key:   "my-test-key",
+			Value: []byte(origin),
+		})
+	})
+
+	// When - Then
+	cli.Close()
+}
+
+func TestAddOriginHeader(t *testing.T) {
+	// Given
+	messageTest := &Message{
+		Headers: []Header{
+			{Key: "test-key1", Value: []byte(`my-test-value1`)},
+			{Key: "test-key2", Value: []byte(`my-test-value2`)},
+		},
+	}
+
+	// When
+	AddOriginHeader(messageTest, "my-service")
+
+	// Then
+	assert.Equal(t, XOriginHeaderName, messageTest.Headers[2].Key)
+	assert.Equal(t, "my-service", string(messageTest.Headers[2].Value))
+}

--- a/internal/service/kafka.go
+++ b/internal/service/kafka.go
@@ -56,7 +56,8 @@ func (container *Container) getKafkaBaseClient() kafka.Client {
 		kafkaProducer = container.decorateKafkaClientWithOpenTelemetry(originalKafkaProducer)
 	}
 
-	return kafka.NewClient(kafkaProducer)
+	client := kafka.NewClient(kafkaProducer)
+	return container.decorateKafkaClientWithOrigin(client)
 }
 
 func (container *Container) decorateKafkaClientWithOpenTelemetry(producer *kafkaconfluent.Producer) *otelconfluent.Producer {
@@ -88,4 +89,12 @@ func (container *Container) decorateKafkaClientWithMetrics(client kafka.Client) 
 	go clientMetric.Record()
 
 	return clientMetric
+}
+
+func (container *Container) decorateKafkaClientWithOrigin(client kafka.Client) kafka.Client {
+	origin := "watcher"
+	if container.Cfg.Replay {
+		origin = "replay"
+	}
+	return kafka.NewClientOrigin(client, origin, kafka.AddOriginHeader)
 }


### PR DESCRIPTION
Add x-origin header in the kafka message to distinguish message coming from the watcher or for the replayer